### PR TITLE
fix: FIlter issues

### DIFF
--- a/electron/main/index.js
+++ b/electron/main/index.js
@@ -64,7 +64,7 @@ async function createWindow() {
 	}
 
 	electronLocalshortcut.register(mainWindow, 'CmdOrCtrl+D', () => {
-		browserWindow.webContents.openDevTools();
+		mainWindow.webContents.openDevTools();
 	});
 
 	if (useSplashScreen) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "log-viewer",
+  "name": "@angry-frog/log-viewer",
   "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -36,10 +36,10 @@ export class FilterService {
 	applyFilter(filter: Filter) {
 		const newFilter = new Filter();
 		newFilter.logLevels = filter.logLevels && filter.logLevels.length > 0 ? filter.logLevels : this.filter.logLevels;
-		newFilter.searchText = filter.searchText;
+		newFilter.searchText = filter.searchText !== undefined && filter.searchText !== null ? filter.searchText : this.filter.searchText;
 		newFilter.from = filter.from ? filter.from : this.filter.from;
 		newFilter.to = filter.to ? filter.to : this.filter.to;
-		newFilter.messageFilters = filter.messageFilters && filter.messageFilters.length > 0 ? filter.messageFilters : this.filter.messageFilters;
+		newFilter.messageFilters = filter.messageFilters ? filter.messageFilters : this.filter.messageFilters;
 		newFilter.groupSameMsg = filter.groupSameMsg !== undefined ? filter.groupSameMsg : this.filter.groupSameMsg;
 
 		// We only need to apply it if it has really changed otherwise we calculate the pages again for nothing.


### PR DESCRIPTION
- Removed check if messagefilters have length > 0 since it prevented to delete the last filter
~ Changed search text check to only check for undefined and null so it won´t be overwritten by the log level filter
~ Fixed window reference in dev tools shortcut